### PR TITLE
Add support for supplying config instead of url

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4,11 +4,11 @@ export type DatabaseClient = {
   query: pg.Pool['query']
 }
 
-export async function connect(url: string): Promise<{
+export async function connect(config: pg.PoolConfig): Promise<{
   client?: DatabaseClient
   done?: () => void
 }> {
-  var pool = new pg.Pool({ connectionString: url })
+  var pool = new pg.Pool(config)
 
   const client = await pool.connect()
 


### PR DESCRIPTION
Would be useful to also have the option of initialising the migrations with a pg configuration object, as opposed to the connection string.